### PR TITLE
Basic scene transition set up

### DIFF
--- a/global/events.gd
+++ b/global/events.gd
@@ -1,0 +1,14 @@
+extends Node
+
+#Battle Events
+signal battle_exited
+
+#Battle Reward Events
+signal battle_reward_exited
+
+#Shop Events
+signal shop_exited
+
+#Map Events
+#TODO replace with room
+signal map_exited(room: String)

--- a/project.godot
+++ b/project.godot
@@ -11,5 +11,18 @@ config_version=5
 [application]
 
 config/name="UndecidedRoguelike"
+run/main_scene="res://scenes/run/run.tscn"
 config/features=PackedStringArray("4.3", "Forward Plus")
 config/icon="res://icon.svg"
+
+[autoload]
+
+Events="*res://global/events.gd"
+
+[display]
+
+window/size/viewport_width=1920
+window/size/viewport_height=1080
+window/size/window_width_override=1280
+window/size/window_height_override=720
+window/stretch/mode="canvas_items"

--- a/scenes/battle/battle.gd
+++ b/scenes/battle/battle.gd
@@ -1,0 +1,7 @@
+extends Node2D
+
+@onready var button: Button = $UI/VBoxContainer/Button
+
+
+func _ready() -> void:
+	button.pressed.connect(Events.battle_exited.emit)

--- a/scenes/battle/battle.tscn
+++ b/scenes/battle/battle.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=2 format=3 uid="uid://c17yhf6jkkgaw"]
+
+[ext_resource type="Script" path="res://scenes/battle/battle.gd" id="1_3svu6"]
+
+[node name="Battle" type="Node2D"]
+script = ExtResource("1_3svu6")
+
+[node name="UI" type="CanvasLayer" parent="."]
+
+[node name="VBoxContainer" type="VBoxContainer" parent="UI"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -60.0
+offset_top = -29.0
+offset_right = 60.0
+offset_bottom = 29.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Label" type="Label" parent="UI/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 96
+text = "Battle Scene"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Button" type="Button" parent="UI/VBoxContainer"]
+layout_mode = 2
+text = "Return to Map"

--- a/scenes/battle_reward/battle_reward.gd
+++ b/scenes/battle_reward/battle_reward.gd
@@ -1,0 +1,7 @@
+extends Node2D
+
+@onready var button: Button = $UI/VBoxContainer/Button
+
+
+func _ready() -> void:
+	button.pressed.connect(Events.battle_reward_exited.emit)

--- a/scenes/battle_reward/battle_reward.tscn
+++ b/scenes/battle_reward/battle_reward.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=2 format=3 uid="uid://judvihkh5tk2"]
+
+[ext_resource type="Script" path="res://scenes/battle_reward/battle_reward.gd" id="1_10gwe"]
+
+[node name="BattleReward" type="Node2D"]
+script = ExtResource("1_10gwe")
+
+[node name="UI" type="CanvasLayer" parent="."]
+
+[node name="VBoxContainer" type="VBoxContainer" parent="UI"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -60.0
+offset_top = -29.0
+offset_right = 60.0
+offset_bottom = 29.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Label" type="Label" parent="UI/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 96
+text = "Battle Reward Scene"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Button" type="Button" parent="UI/VBoxContainer"]
+layout_mode = 2
+text = "Return to Map"

--- a/scenes/map/map.gd
+++ b/scenes/map/map.gd
@@ -1,0 +1,25 @@
+extends Node2D
+
+@onready var battle_button: Button = $UI/VBoxContainer/BattleButton
+@onready var battle_reward_button: Button = $UI/VBoxContainer/BattleRewardButton
+@onready var shop_button: Button = $UI/VBoxContainer/ShopButton
+
+@onready var ui: CanvasLayer = $UI
+
+
+func _ready() -> void:
+	battle_button.pressed.connect(_on_room_selected.bind('battle'))
+	battle_reward_button.pressed.connect(_on_room_selected.bind('battle_reward'))
+	shop_button.pressed.connect(_on_room_selected.bind('shop'))
+
+
+func show_map() -> void:
+	ui.show()
+
+
+func hide_map() -> void:
+	ui.hide()
+
+
+func _on_room_selected(room: String) -> void:
+	Events.map_exited.emit(room)

--- a/scenes/map/map.tscn
+++ b/scenes/map/map.tscn
@@ -1,0 +1,44 @@
+[gd_scene load_steps=2 format=3 uid="uid://pxeh6kyk26er"]
+
+[ext_resource type="Script" path="res://scenes/map/map.gd" id="1_00pp3"]
+
+[node name="Map" type="Node2D"]
+script = ExtResource("1_00pp3")
+
+[node name="UI" type="CanvasLayer" parent="."]
+
+[node name="VBoxContainer" type="VBoxContainer" parent="UI"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -60.0
+offset_top = -29.0
+offset_right = 60.0
+offset_bottom = 29.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 16
+
+[node name="Label" type="Label" parent="UI/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 96
+text = "Map Scene"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="BattleButton" type="Button" parent="UI/VBoxContainer"]
+layout_mode = 2
+text = "Go to Battle
+"
+
+[node name="BattleRewardButton" type="Button" parent="UI/VBoxContainer"]
+layout_mode = 2
+text = "Go to Battle Reward
+"
+
+[node name="ShopButton" type="Button" parent="UI/VBoxContainer"]
+layout_mode = 2
+text = "Go to Shop
+"

--- a/scenes/run/run.gd
+++ b/scenes/run/run.gd
@@ -1,0 +1,57 @@
+extends Node
+
+const BATTLE_SCENE := preload("res://scenes/battle/battle.tscn")
+const BATTLE_REWARD_SCENE := preload("res://scenes/battle_reward/battle_reward.tscn")
+const SHOP_SCENE := preload("res://scenes/shop/shop.tscn")
+
+@onready var current_view: Node = $CurrentView
+@onready var map: Node2D = $Map
+
+
+func _ready() -> void:
+	Events.battle_exited.connect(_show_map)
+	Events.battle_reward_exited.connect(_show_map)
+	Events.shop_exited.connect(_show_map)
+	Events.map_exited.connect(_on_map_exited)
+
+
+func _change_view(scene: PackedScene) -> Node:
+	if current_view.get_child_count() > 0:
+		current_view.get_child(0).queue_free()
+		
+	var new_view := scene.instantiate()
+	current_view.add_child(new_view)
+	map.hide_map()
+	
+	return new_view
+
+
+func _show_map() -> void:
+	if current_view.get_child_count() > 0:
+		current_view.get_child(0).queue_free()
+		
+	map.show_map()
+
+
+func _on_map_exited(room_name: String) -> void:
+	# TODO replace with room type matching
+	
+	match room_name:
+		'battle':
+			_on_battle_entered()
+		'battle_reward':
+			_on_battle_reward_entered()
+		'shop':
+			_on_shop_entered()
+
+
+func _on_battle_entered() -> void:
+	_change_view(BATTLE_SCENE)
+
+
+func _on_battle_reward_entered() -> void:
+	_change_view(BATTLE_REWARD_SCENE)
+
+
+func _on_shop_entered() -> void:
+	_change_view(SHOP_SCENE)

--- a/scenes/run/run.tscn
+++ b/scenes/run/run.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=3 format=3 uid="uid://d0dmahppmgl43"]
+
+[ext_resource type="Script" path="res://scenes/run/run.gd" id="1_w8t3s"]
+[ext_resource type="PackedScene" uid="uid://pxeh6kyk26er" path="res://scenes/map/map.tscn" id="2_421io"]
+
+[node name="Run" type="Node"]
+script = ExtResource("1_w8t3s")
+
+[node name="CurrentView" type="Node" parent="."]
+
+[node name="Map" parent="." instance=ExtResource("2_421io")]

--- a/scenes/shop/shop.gd
+++ b/scenes/shop/shop.gd
@@ -1,0 +1,7 @@
+extends Node2D
+
+@onready var button: Button = $UI/VBoxContainer/Button
+
+
+func _ready() -> void:
+	button.pressed.connect(Events.shop_exited.emit)

--- a/scenes/shop/shop.tscn
+++ b/scenes/shop/shop.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=2 format=3 uid="uid://bb2k4gvoay8vi"]
+
+[ext_resource type="Script" path="res://scenes/shop/shop.gd" id="1_cpact"]
+
+[node name="Shop" type="Node2D"]
+script = ExtResource("1_cpact")
+
+[node name="UI" type="CanvasLayer" parent="."]
+
+[node name="VBoxContainer" type="VBoxContainer" parent="UI"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -60.0
+offset_top = -29.0
+offset_right = 60.0
+offset_bottom = 29.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Label" type="Label" parent="UI/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 96
+text = "Shop Scene"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Button" type="Button" parent="UI/VBoxContainer"]
+layout_mode = 2
+text = "Return to Map"


### PR DESCRIPTION
Created run scene to handle scene transitions and host the map
On request to change scene remove an existing scene, hide map and overlay new scene
On exiting a scene, queue free it then show the map